### PR TITLE
Benchmarks for bls multisig

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
 test:
 	@echo "  >  Running unit tests"
 	go test -cover -race -coverprofile=coverage.txt -covermode=atomic -v ./...
+
+benchmark-multisig:
+	cd signing/mcl/multisig/ && \
+		go test -v -bench=. -count 1 -run=^#
+

--- a/signing/mcl/multisig/bls_bench_test.go
+++ b/signing/mcl/multisig/bls_bench_test.go
@@ -1,0 +1,65 @@
+package multisig_test
+
+import (
+	"testing"
+
+	crypto "github.com/ElrondNetwork/elrond-go-crypto"
+	"github.com/ElrondNetwork/elrond-go-crypto/mock"
+	"github.com/ElrondNetwork/elrond-go-crypto/signing"
+	"github.com/ElrondNetwork/elrond-go-crypto/signing/mcl"
+	"github.com/ElrondNetwork/elrond-go-crypto/signing/mcl/multisig"
+	"github.com/herumi/bls-go-binary/bls"
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkPreparePublicKeys(b *testing.B) {
+	hasher := &mock.HasherSpongeMock{}
+
+	pubKeys := createBLSPubKeys(400)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		prepPubKeys, err := multisig.PreparePublicKeys(pubKeys, hasher, pubKeys[0].Suite())
+		require.Nil(b, err)
+		require.NotNil(b, prepPubKeys)
+	}
+}
+
+func Benchmark_VerifyAggregatedSigWithoutPrepare(b *testing.B) {
+	msg := []byte("testMessage")
+
+	hasher := &mock.HasherSpongeMock{}
+	llSig := &multisig.BlsMultiSigner{Hasher: hasher}
+	pubKeys, sigShares := createSigSharesBLS(400, msg)
+	aggSigBytes, err := llSig.AggregateSignatures(pubKeys[0].Suite(), sigShares, pubKeys)
+	require.Nil(b, err)
+
+	prepPubKeys, err := multisig.PreparePublicKeys(pubKeys, hasher, pubKeys[0].Suite())
+	require.Nil(b, err)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		aggSig := &bls.Sign{}
+		err = aggSig.Deserialize(aggSigBytes)
+		require.Nil(b, err)
+
+		res := aggSig.FastAggregateVerify(prepPubKeys, msg)
+		require.True(b, res)
+	}
+}
+
+func createBLSPubKeys(
+	nPubKeys uint16,
+) (pubKeys []crypto.PublicKey) {
+	suite := mcl.NewSuiteBLS12()
+	kg := signing.NewKeyGenerator(suite)
+
+	pubKeys = make([]crypto.PublicKey, nPubKeys)
+
+	for i := uint16(0); i < nPubKeys; i++ {
+		_, pk := kg.GeneratePair()
+		pubKeys[i] = pk
+	}
+
+	return pubKeys
+}

--- a/signing/mcl/multisig/bls_bench_test.go
+++ b/signing/mcl/multisig/bls_bench_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func BenchmarkPreparePublicKeys(b *testing.B) {
+func Benchmark_PreparePublicKeys(b *testing.B) {
 	hasher := &mock.HasherSpongeMock{}
 
 	pubKeys := createBLSPubKeys(400)
@@ -22,6 +22,22 @@ func BenchmarkPreparePublicKeys(b *testing.B) {
 		prepPubKeys, err := multisig.PreparePublicKeys(pubKeys, hasher, pubKeys[0].Suite())
 		require.Nil(b, err)
 		require.NotNil(b, prepPubKeys)
+	}
+}
+
+func Benchmark_VerifyAggregatedSig(b *testing.B) {
+	msg := []byte("testMessage")
+
+	hasher := &mock.HasherSpongeMock{}
+	llSig := &multisig.BlsMultiSigner{Hasher: hasher}
+	pubKeys, sigShares := createSigSharesBLS(400, msg)
+	aggSigBytes, err := llSig.AggregateSignatures(pubKeys[0].Suite(), sigShares, pubKeys)
+	require.Nil(b, err)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err = llSig.VerifyAggregatedSig(pubKeys[0].Suite(), pubKeys, aggSigBytes, msg)
+		require.Nil(b, err)
 	}
 }
 

--- a/signing/mcl/multisig/bls_bench_test.go
+++ b/signing/mcl/multisig/bls_bench_test.go
@@ -12,16 +12,42 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Benchmark_PreparePublicKeys(b *testing.B) {
+func Benchmark_PreparePublicKeys63(b *testing.B) {
+	benchmarkPreparePublicKeys(63, b)
+}
+
+func Benchmark_PreparePublicKeys400(b *testing.B) {
+	benchmarkPreparePublicKeys(400, b)
+}
+
+func benchmarkPreparePublicKeys(nPubKeys int, b *testing.B) {
 	hasher := &mock.HasherSpongeMock{}
 
-	pubKeys := createBLSPubKeys(400)
+	pubKeys := createBLSPubKeys(nPubKeys)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		prepPubKeys, err := multisig.PreparePublicKeys(pubKeys, hasher, pubKeys[0].Suite())
 		require.Nil(b, err)
 		require.NotNil(b, prepPubKeys)
+	}
+}
+
+func Benchmark_ConcatPubKeys63(b *testing.B) {
+	benchmarkConcatPubKeys(63, b)
+}
+
+func Benchmark_ConcatPubKeys400(b *testing.B) {
+	benchmarkConcatPubKeys(400, b)
+}
+
+func benchmarkConcatPubKeys(nPubKeys int, b *testing.B) {
+	pubKeys := createBLSPubKeys(nPubKeys)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := multisig.ConcatPubKeys(pubKeys)
+		require.Nil(b, err)
 	}
 }
 

--- a/signing/mcl/multisig/bls_bench_test.go
+++ b/signing/mcl/multisig/bls_bench_test.go
@@ -3,14 +3,16 @@ package multisig_test
 import (
 	"testing"
 
+	"github.com/ElrondNetwork/elrond-go-core/hashing/blake2b"
 	crypto "github.com/ElrondNetwork/elrond-go-crypto"
-	"github.com/ElrondNetwork/elrond-go-crypto/mock"
 	"github.com/ElrondNetwork/elrond-go-crypto/signing"
 	"github.com/ElrondNetwork/elrond-go-crypto/signing/mcl"
 	"github.com/ElrondNetwork/elrond-go-crypto/signing/mcl/multisig"
 	"github.com/herumi/bls-go-binary/bls"
 	"github.com/stretchr/testify/require"
 )
+
+const blsHashSize = 16
 
 func Benchmark_PreparePublicKeys63(b *testing.B) {
 	benchmarkPreparePublicKeys(63, b)
@@ -21,7 +23,8 @@ func Benchmark_PreparePublicKeys400(b *testing.B) {
 }
 
 func benchmarkPreparePublicKeys(nPubKeys int, b *testing.B) {
-	hasher := &mock.HasherSpongeMock{}
+	hasher, err := blake2b.NewBlake2bWithSize(blsHashSize)
+	require.Nil(b, err)
 
 	pubKeys := createBLSPubKeys(nPubKeys)
 
@@ -62,7 +65,9 @@ func Benchmark_VerifyAggregatedSig400(b *testing.B) {
 func benchmarkVerifyAggregatedSig(nPubKeys uint16, b *testing.B) {
 	msg := []byte(testMessage)
 
-	hasher := &mock.HasherSpongeMock{}
+	hasher, err := blake2b.NewBlake2bWithSize(blsHashSize)
+	require.Nil(b, err)
+
 	llSig := &multisig.BlsMultiSigner{Hasher: hasher}
 	pubKeys, sigShares := createSigSharesBLS(nPubKeys, msg)
 	aggSigBytes, err := llSig.AggregateSignatures(pubKeys[0].Suite(), sigShares, pubKeys)
@@ -86,7 +91,8 @@ func Benchmark_AggregatedSig400(b *testing.B) {
 func benchmarkAggregatedSig(nPubKeys uint16, b *testing.B) {
 	msg := []byte(testMessage)
 
-	hasher := &mock.HasherSpongeMock{}
+	hasher, err := blake2b.NewBlake2bWithSize(blsHashSize)
+	require.Nil(b, err)
 	llSig := &multisig.BlsMultiSigner{Hasher: hasher}
 	pubKeys, sigShares := createSigSharesBLS(nPubKeys, msg)
 
@@ -100,7 +106,8 @@ func benchmarkAggregatedSig(nPubKeys uint16, b *testing.B) {
 func Benchmark_VerifyAggregatedSigWithoutPrepare(b *testing.B) {
 	msg := []byte(testMessage)
 
-	hasher := &mock.HasherSpongeMock{}
+	hasher, err := blake2b.NewBlake2bWithSize(blsHashSize)
+	require.Nil(b, err)
 	llSig := &multisig.BlsMultiSigner{Hasher: hasher}
 	pubKeys, sigShares := createSigSharesBLS(400, msg)
 	aggSigBytes, err := llSig.AggregateSignatures(pubKeys[0].Suite(), sigShares, pubKeys)
@@ -169,7 +176,8 @@ func Benchmark_HashPublicKeyPoints400(b *testing.B) {
 }
 
 func benchmarkHashPublicKeyPoints(nPubKeys int, b *testing.B) {
-	hasher := &mock.HasherSpongeMock{}
+	hasher, err := blake2b.NewBlake2bWithSize(blsHashSize)
+	require.Nil(b, err)
 
 	pubKeys := createBLSPubKeys(nPubKeys)
 	concatPubKeys, err := multisig.ConcatPubKeys(pubKeys)

--- a/signing/mcl/multisig/bls_bench_test.go
+++ b/signing/mcl/multisig/bls_bench_test.go
@@ -54,6 +54,29 @@ func benchmarkConcatPubKeys(nPubKeys int, b *testing.B) {
 	}
 }
 
+func Benchmark_AggregatedSig63(b *testing.B) {
+	benchmarkAggregatedSig(63, b)
+}
+
+func Benchmark_AggregatedSig400(b *testing.B) {
+	benchmarkAggregatedSig(400, b)
+}
+
+func benchmarkAggregatedSig(nPubKeys uint16, b *testing.B) {
+	msg := []byte(testMessage)
+
+	hasher, err := blake2b.NewBlake2bWithSize(blsHashSize)
+	require.Nil(b, err)
+	llSig := &multisig.BlsMultiSigner{Hasher: hasher}
+	pubKeys, sigShares := createSigSharesBLS(nPubKeys, msg)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := llSig.AggregateSignatures(pubKeys[0].Suite(), sigShares, pubKeys)
+		require.Nil(b, err)
+	}
+}
+
 func Benchmark_VerifyAggregatedSig63(b *testing.B) {
 	benchmarkVerifyAggregatedSig(63, b)
 }
@@ -80,36 +103,21 @@ func benchmarkVerifyAggregatedSig(nPubKeys uint16, b *testing.B) {
 	}
 }
 
-func Benchmark_AggregatedSig63(b *testing.B) {
-	benchmarkAggregatedSig(63, b)
+func Benchmark_VerifyAggregatedSigWithoutPrepare63(b *testing.B) {
+	benchmarkVerifyAggregatedSigWithoutPrepare(63, b)
 }
 
-func Benchmark_AggregatedSig400(b *testing.B) {
-	benchmarkAggregatedSig(400, b)
+func Benchmark_VerifyAggregatedSigWithoutPrepare400(b *testing.B) {
+	benchmarkVerifyAggregatedSigWithoutPrepare(400, b)
 }
 
-func benchmarkAggregatedSig(nPubKeys uint16, b *testing.B) {
+func benchmarkVerifyAggregatedSigWithoutPrepare(nPubKeys uint16, b *testing.B) {
 	msg := []byte(testMessage)
 
 	hasher, err := blake2b.NewBlake2bWithSize(blsHashSize)
 	require.Nil(b, err)
 	llSig := &multisig.BlsMultiSigner{Hasher: hasher}
 	pubKeys, sigShares := createSigSharesBLS(nPubKeys, msg)
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_, err := llSig.AggregateSignatures(pubKeys[0].Suite(), sigShares, pubKeys)
-		require.Nil(b, err)
-	}
-}
-
-func Benchmark_VerifyAggregatedSigWithoutPrepare(b *testing.B) {
-	msg := []byte(testMessage)
-
-	hasher, err := blake2b.NewBlake2bWithSize(blsHashSize)
-	require.Nil(b, err)
-	llSig := &multisig.BlsMultiSigner{Hasher: hasher}
-	pubKeys, sigShares := createSigSharesBLS(400, msg)
 	aggSigBytes, err := llSig.AggregateSignatures(pubKeys[0].Suite(), sigShares, pubKeys)
 	require.Nil(b, err)
 


### PR DESCRIPTION
Multiple benchmarks for signing bls multisig, with 63 and 400 nodes.