### PR TITLE
feat(zk): Add guards and tests for nil or empty inputs

### DIFF
--- a/zk/groth16/verify.go
+++ b/zk/groth16/verify.go
@@ -11,6 +11,10 @@ import (
 
 // VerifyGroth16 verifies the groth16 proof from the given input and curve id
 func VerifyGroth16(curveID uint16, proofBytes, vkBytes, pubWitnessBytes []byte) (bool, error) {
+	if len(proofBytes) == 0 || len(vkBytes) == 0 || len(pubWitnessBytes) == 0 {
+		return false, lowLevelFeatures.ErrNilOrEmptyInput
+	}
+
 	_, ok := lowLevelFeatures.SupportedCurvesRegistry[ecc.ID(curveID)]
 	if !ok {
 		return false, lowLevelFeatures.ErrInvalidCurve

--- a/zk/groth16/verify_test.go
+++ b/zk/groth16/verify_test.go
@@ -91,10 +91,6 @@ func TestVerifyGroth16(t *testing.T) {
 	ok, _ = VerifyGroth16(uint16(ecc.BN254), proofBytes, invalidVkBytes, pubWitnessBytes)
 	require.False(t, ok)
 
-	// test error cases from my previous fix
-	_, err = VerifyGroth16(uint16(ecc.BN254), []byte("invalid"), vkBytes, pubWitnessBytes)
-	require.Error(t, err)
-
 	// create a dummy witness for a different curve
 	invalidWitness, err := witness.New(ecc.BLS12_381.ScalarField())
 	require.NoError(t, err)
@@ -105,12 +101,37 @@ func TestVerifyGroth16(t *testing.T) {
 	require.False(t, ok)
 
 	// test invalid curve
-	TestVerifyGroth16_InvalidCurve(t)
+	_, err = VerifyGroth16(uint16(ecc.UNKNOWN), proofBytes, vkBytes, pubWitnessBytes)
+	require.Equal(t, lowLevelFeatures.ErrInvalidCurve, err)
+	_, err = VerifyGroth16(42, proofBytes, vkBytes, pubWitnessBytes)
+	require.Equal(t, lowLevelFeatures.ErrInvalidCurve, err)
 }
 
-func TestVerifyGroth16_InvalidCurve(t *testing.T) {
-	_, err := VerifyGroth16(uint16(ecc.UNKNOWN), nil, nil, nil)
-	require.Equal(t, lowLevelFeatures.ErrInvalidCurve, err)
-	_, err = VerifyGroth16(42, nil, nil, nil)
-	require.Equal(t, lowLevelFeatures.ErrInvalidCurve, err)
+func TestVerifyGroth16_NilOrEmptyInput(t *testing.T) {
+	// Invalid proof
+	verified, err := VerifyGroth16(uint16(ecc.BN254), nil, []byte("vk"), []byte("pubw"))
+	require.False(t, verified)
+	require.ErrorIs(t, err, lowLevelFeatures.ErrNilOrEmptyInput)
+
+	verified, err = VerifyGroth16(uint16(ecc.BN254), []byte{}, []byte("vk"), []byte("pubw"))
+	require.False(t, verified)
+	require.ErrorIs(t, err, lowLevelFeatures.ErrNilOrEmptyInput)
+
+	// Invalid vk
+	verified, err = VerifyGroth16(uint16(ecc.BN254), []byte("proof"), nil, []byte("pubw"))
+	require.False(t, verified)
+	require.ErrorIs(t, err, lowLevelFeatures.ErrNilOrEmptyInput)
+
+	verified, err = VerifyGroth16(uint16(ecc.BN254), []byte("proof"), []byte{}, []byte("pubw"))
+	require.False(t, verified)
+	require.ErrorIs(t, err, lowLevelFeatures.ErrNilOrEmptyInput)
+
+	// Invalid public witness
+	verified, err = VerifyGroth16(uint16(ecc.BN254), []byte("proof"), []byte("vk"), nil)
+	require.False(t, verified)
+	require.ErrorIs(t, err, lowLevelFeatures.ErrNilOrEmptyInput)
+
+	verified, err = VerifyGroth16(uint16(ecc.BN254), []byte("proof"), []byte("vk"), []byte{})
+	require.False(t, verified)
+	require.ErrorIs(t, err, lowLevelFeatures.ErrNilOrEmptyInput)
 }

--- a/zk/lowLevelFeatures/ec.go
+++ b/zk/lowLevelFeatures/ec.go
@@ -2,6 +2,9 @@ package lowLevelFeatures
 
 // PointAdd performs addition on two points of a specified curve
 func PointAdd(curveID ID, group GroupID, point1Bytes, point2Bytes []byte) ([]byte, error) {
+	if len(point1Bytes) == 0 || len(point2Bytes) == 0 {
+		return nil, ErrNilOrEmptyInput
+	}
 	handler, ok := EcRegistry[ECParams{curveID, group}]
 	if !ok {
 		return nil, ErrInvalidCurve
@@ -12,6 +15,9 @@ func PointAdd(curveID ID, group GroupID, point1Bytes, point2Bytes []byte) ([]byt
 
 // ScalarMul performs scalar multiplication on the specified curve
 func ScalarMul(curveID ID, group GroupID, point, scalar []byte) ([]byte, error) {
+	if len(point) == 0 || len(scalar) == 0 {
+		return nil, ErrNilOrEmptyInput
+	}
 	handler, ok := EcRegistry[ECParams{curveID, group}]
 	if !ok {
 		return nil, ErrInvalidCurve
@@ -22,6 +28,9 @@ func ScalarMul(curveID ID, group GroupID, point, scalar []byte) ([]byte, error) 
 
 // MultiExp performs multi exponent on the specified curve
 func MultiExp(curveID ID, group GroupID, points [][]byte, scalars [][]byte) ([]byte, error) {
+	if len(points) == 0 || len(scalars) == 0 {
+		return nil, ErrNilOrEmptyInput
+	}
 	handler, ok := EcRegistry[ECParams{curveID, group}]
 	if !ok {
 		return nil, ErrInvalidCurve
@@ -32,6 +41,9 @@ func MultiExp(curveID ID, group GroupID, points [][]byte, scalars [][]byte) ([]b
 
 // MapToCurve performs map to curve operation on the specified curve
 func MapToCurve(curveID ID, group GroupID, element []byte) ([]byte, error) {
+	if len(element) == 0 {
+		return nil, ErrNilOrEmptyInput
+	}
 	handler, ok := EcRegistry[ECParams{curveID, group}]
 	if !ok {
 		return nil, ErrInvalidCurve
@@ -42,6 +54,9 @@ func MapToCurve(curveID ID, group GroupID, element []byte) ([]byte, error) {
 
 // PairingCheck performs pairing check operation on the specified curve
 func PairingCheck(curveID ID, pointsG1, pointsG2 [][]byte) (bool, error) {
+	if len(pointsG1) == 0 || len(pointsG2) == 0 {
+		return false, ErrNilOrEmptyInput
+	}
 	handler, ok := PairingRegistry[curveID]
 	if !ok {
 		return false, ErrInvalidCurve

--- a/zk/lowLevelFeatures/ec_test.go
+++ b/zk/lowLevelFeatures/ec_test.go
@@ -142,7 +142,73 @@ func TestPairingCheck(t *testing.T) {
 	})
 
 	t.Run("InvalidCurve", func(t *testing.T) {
-		_, err := PairingCheck(Unknown, nil, nil)
+		_, err := PairingCheck(Unknown, [][]byte{[]byte("p1")}, [][]byte{[]byte("p2")})
 		require.ErrorIs(t, err, ErrInvalidCurve)
+	})
+}
+
+func TestNilOrEmptyInputs(t *testing.T) {
+	t.Run("PointAdd", func(t *testing.T) {
+		_, err := PointAdd(BLS12_381, G1, nil, []byte("point2"))
+		require.ErrorIs(t, err, ErrNilOrEmptyInput)
+
+		_, err = PointAdd(BLS12_381, G1, []byte{}, []byte("point2"))
+		require.ErrorIs(t, err, ErrNilOrEmptyInput)
+
+		_, err = PointAdd(BLS12_381, G1, []byte("point1"), nil)
+		require.ErrorIs(t, err, ErrNilOrEmptyInput)
+
+		_, err = PointAdd(BLS12_381, G1, []byte("point1"), []byte{})
+		require.ErrorIs(t, err, ErrNilOrEmptyInput)
+	})
+
+	t.Run("ScalarMul", func(t *testing.T) {
+		_, err := ScalarMul(BLS12_381, G1, nil, []byte("scalar"))
+		require.ErrorIs(t, err, ErrNilOrEmptyInput)
+
+		_, err = ScalarMul(BLS12_381, G1, []byte{}, []byte("scalar"))
+		require.ErrorIs(t, err, ErrNilOrEmptyInput)
+
+		_, err = ScalarMul(BLS12_381, G1, []byte("point"), nil)
+		require.ErrorIs(t, err, ErrNilOrEmptyInput)
+
+		_, err = ScalarMul(BLS12_381, G1, []byte("point"), []byte{})
+		require.ErrorIs(t, err, ErrNilOrEmptyInput)
+	})
+
+	t.Run("MultiExp", func(t *testing.T) {
+		_, err := MultiExp(BLS12_381, G1, nil, [][]byte{[]byte("scalar")})
+		require.ErrorIs(t, err, ErrNilOrEmptyInput)
+
+		_, err = MultiExp(BLS12_381, G1, [][]byte{}, [][]byte{[]byte("scalar")})
+		require.ErrorIs(t, err, ErrNilOrEmptyInput)
+
+		_, err = MultiExp(BLS12_381, G1, [][]byte{[]byte("point")}, nil)
+		require.ErrorIs(t, err, ErrNilOrEmptyInput)
+
+		_, err = MultiExp(BLS12_381, G1, [][]byte{[]byte("point")}, [][]byte{})
+		require.ErrorIs(t, err, ErrNilOrEmptyInput)
+	})
+
+	t.Run("MapToCurve", func(t *testing.T) {
+		_, err := MapToCurve(BLS12_381, G1, nil)
+		require.ErrorIs(t, err, ErrNilOrEmptyInput)
+
+		_, err = MapToCurve(BLS12_381, G1, []byte{})
+		require.ErrorIs(t, err, ErrNilOrEmptyInput)
+	})
+
+	t.Run("PairingCheck", func(t *testing.T) {
+		_, err := PairingCheck(BLS12_381, nil, [][]byte{[]byte("point2")})
+		require.ErrorIs(t, err, ErrNilOrEmptyInput)
+
+		_, err = PairingCheck(BLS12_381, [][]byte{}, [][]byte{[]byte("point2")})
+		require.ErrorIs(t, err, ErrNilOrEmptyInput)
+
+		_, err = PairingCheck(BLS12_381, [][]byte{[]byte("point1")}, nil)
+		require.ErrorIs(t, err, ErrNilOrEmptyInput)
+
+		_, err = PairingCheck(BLS12_381, [][]byte{[]byte("point1")}, [][]byte{})
+		require.ErrorIs(t, err, ErrNilOrEmptyInput)
 	})
 }

--- a/zk/lowLevelFeatures/errors.go
+++ b/zk/lowLevelFeatures/errors.go
@@ -16,3 +16,6 @@ var ErrPointsAndScalarsShouldMatch = errors.New("the number of points and scalar
 
 // ErrInvalidFpElement signals invalid field element error
 var ErrInvalidFpElement = errors.New("invalid field element")
+
+// ErrNilOrEmptyInput signals nil or empty input error
+var ErrNilOrEmptyInput = errors.New("nil or empty input provided")

--- a/zk/plonk/verify.go
+++ b/zk/plonk/verify.go
@@ -11,6 +11,10 @@ import (
 
 // VerifyPlonk verifies the plonk signature on the given curveID
 func VerifyPlonk(curveID uint16, proofBytes, vkBytes, pubWitnessBytes []byte) (bool, error) {
+	if len(proofBytes) == 0 || len(vkBytes) == 0 || len(pubWitnessBytes) == 0 {
+		return false, lowLevelFeatures.ErrNilOrEmptyInput
+	}
+
 	_, ok := lowLevelFeatures.SupportedCurvesRegistry[ecc.ID(curveID)]
 	if !ok {
 		return false, lowLevelFeatures.ErrInvalidCurve

--- a/zk/plonk/verify_test.go
+++ b/zk/plonk/verify_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/consensys/gnark/frontend"
 	"github.com/consensys/gnark/frontend/cs/scs"
 	"github.com/consensys/gnark/test/unsafekzg"
+	"github.com/multiversx/mx-chain-crypto-go/zk/lowLevelFeatures"
 	"github.com/stretchr/testify/require"
 )
 
@@ -56,23 +57,37 @@ func TestVerifyPlonk(t *testing.T) {
 	require.True(t, verified)
 	require.Nil(t, err)
 
-	// Invalid proof
-	verified, err = VerifyPlonk(uint16(ecc.BLS12_381), []byte{}, serializedVK.Bytes(), pubWBytes)
-	require.False(t, verified)
-	require.Error(t, err)
-
-	// Invalid public witness
-	verified, err = VerifyPlonk(uint16(ecc.BLS12_381), serializedProof.Bytes(), serializedVK.Bytes(), []byte{})
-	require.False(t, verified)
-	require.Error(t, err)
-
-	// Invalid vk
-	verified, err = VerifyPlonk(uint16(ecc.BLS12_381), serializedProof.Bytes(), []byte{}, pubWBytes)
-	require.False(t, verified)
-	require.Error(t, err)
-
 	_, err = VerifyPlonk(uint16(ecc.UNKNOWN), serializedProof.Bytes(), serializedVK.Bytes(), pubWBytes)
 	require.Error(t, err)
 	_, err = VerifyPlonk(42, serializedProof.Bytes(), serializedVK.Bytes(), pubWBytes)
 	require.Error(t, err)
+}
+
+func TestVerifyPlonk_NilOrEmptyInput(t *testing.T) {
+	// Invalid proof
+	verified, err := VerifyPlonk(uint16(ecc.BLS12_381), nil, []byte("vk"), []byte("pubw"))
+	require.False(t, verified)
+	require.ErrorIs(t, err, lowLevelFeatures.ErrNilOrEmptyInput)
+
+	verified, err = VerifyPlonk(uint16(ecc.BLS12_381), []byte{}, []byte("vk"), []byte("pubw"))
+	require.False(t, verified)
+	require.ErrorIs(t, err, lowLevelFeatures.ErrNilOrEmptyInput)
+
+	// Invalid vk
+	verified, err = VerifyPlonk(uint16(ecc.BLS12_381), []byte("proof"), nil, []byte("pubw"))
+	require.False(t, verified)
+	require.ErrorIs(t, err, lowLevelFeatures.ErrNilOrEmptyInput)
+
+	verified, err = VerifyPlonk(uint16(ecc.BLS12_381), []byte("proof"), []byte{}, []byte("pubw"))
+	require.False(t, verified)
+	require.ErrorIs(t, err, lowLevelFeatures.ErrNilOrEmptyInput)
+
+	// Invalid public witness
+	verified, err = VerifyPlonk(uint16(ecc.BLS12_381), []byte("proof"), []byte("vk"), nil)
+	require.False(t, verified)
+	require.ErrorIs(t, err, lowLevelFeatures.ErrNilOrEmptyInput)
+
+	verified, err = VerifyPlonk(uint16(ecc.BLS12_381), []byte("proof"), []byte("vk"), []byte{})
+	require.False(t, verified)
+	require.ErrorIs(t, err, lowLevelFeatures.ErrNilOrEmptyInput)
 }


### PR DESCRIPTION
Adds checks for nil or empty byte slices to the public functions in the zk package to prevent panics when handling invalid inputs.

Also adds comprehensive unit tests to verify that the new error, `ErrNilOrEmptyInput`, is returned when functions are called with nil or empty inputs.

The following functions are now protected and tested:
- `VerifyPlonk`
- `VerifyGroth16`
- `PointAdd`
- `ScalarMul`
- `MultiExp`
- `MapToCurve`
- `PairingCheck`